### PR TITLE
Feature: distroless docker images

### DIFF
--- a/deployment/helm/edc-controlplane/templates/deployment.yaml
+++ b/deployment/helm/edc-controlplane/templates/deployment.yaml
@@ -38,9 +38,6 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}{{- if .Values.flavor }}-{{ .Values.flavor }}{{- end -}}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          env:
-            - name: CONFIGURATION_PROPERTIES
-              value: "/etc/edc/configuration.properties"
           ports:
             - name: http
               containerPort: 80
@@ -57,7 +54,8 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
             - name: configuration
-              mountPath: /etc/edc
+              mountPath: /app/configuration.properties
+              subPath: configuration.properties
       volumes:
         - name: configuration
           configMap:

--- a/deployment/helm/edc-dataplane/templates/deployment.yaml
+++ b/deployment/helm/edc-dataplane/templates/deployment.yaml
@@ -38,9 +38,6 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          env:
-            - name: CONFIGURATION_PROPERTIES
-              value: "/etc/edc/configuration.properties"
           ports:
             - name: http
               containerPort: 80
@@ -57,7 +54,8 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
             - name: configuration
-              mountPath: /etc/edc
+              mountPath: /app/configuration.properties
+              subPath: configuration.properties
       volumes:
         - name: configuration
           configMap:

--- a/edc-controlplane/edc-controlplane-cosmosdb/src/main/docker/Dockerfile
+++ b/edc-controlplane/edc-controlplane-cosmosdb/src/main/docker/Dockerfile
@@ -1,17 +1,8 @@
-FROM openjdk:11-jre-slim-buster
+FROM gcr.io/distroless/java11-debian11
 ARG JAR
-
-ENV CONFIGURATION_PROPERTIES=/app/configuration.properties
-
-RUN useradd --create-home app
 
 WORKDIR /app
 
-USER app
-
 COPY $JAR edc-controlplane.jar
 
-ENTRYPOINT java \
-    -Djava.security.edg=file:/dev/.urandom \
-    -Dedc.fs.config="${CONFIGURATION_PROPERTIES}" \
-    -jar edc-controlplane.jar
+CMD ["-Djava.security.edg=file:/dev/.urandom", "-Dedc.fs.config=/app/configuration.properties", "-jar", "edc-controlplane.jar"]

--- a/edc-dataplane/src/main/docker/Dockerfile
+++ b/edc-dataplane/src/main/docker/Dockerfile
@@ -1,17 +1,8 @@
-FROM openjdk:11-jre-slim-buster
+FROM gcr.io/distroless/java11-debian11
 ARG JAR
-
-ENV CONFIGURATION_PROPERTIES=/app/configuration.properties
-
-RUN useradd --create-home app
 
 WORKDIR /app
 
-USER app
-
 COPY $JAR edc-dataplane.jar
 
-ENTRYPOINT java \
-    -Djava.security.edg=file:/dev/.urandom \
-    -Dedc.fs.config="${CONFIGURATION_PROPERTIES}" \
-    -jar edc-dataplane.jar
+CMD ["-Djava.security.edg=file:/dev/.urandom", "-Dedc.fs.config=/app/configuration.properties", "-jar", "edc-dataplane.jar"]


### PR DESCRIPTION
Replaces __openjdk:11-jre-slim-buster__ docker base image by __gcr.io/distroless/java11-debian11__ to become distroless.
configuration.properties path has been adjusted within each helm chart.

<sub> Denis Neuling <denis.neuling@daimler.com>, Daimler TSS GmbH, [legal info/Impressum](https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md)
