### PR TITLE
Bumb edc to 3305340d6a19ba919540d28a731b3cab6d23857a

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - develop
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
   pull_request:
@@ -37,7 +38,7 @@ jobs:
       run: |-
         [ ! -d "edc" ] && git submodule add https://github.com/eclipse-dataspaceconnector/DataSpaceConnector.git edc
         git submodule update --init
-        git -C edc checkout 705a44712fecb9cf5ac18622311e6a2dbd86ffc3
+        git -C edc checkout 3305340d6a19ba919540d28a731b3cab6d23857a
     -
       name: Set up JDK 11
       uses: actions/setup-java@v2
@@ -61,7 +62,7 @@ jobs:
         GITHUB_PACKAGE_USERNAME: ${{ github.actor }}
         GITHUB_PACKAGE_PASSWORD: ${{ secrets.CXNG_GHCR_PAT }}
     -
-      name: Docker Metadata
+      name: edc-controlplane-memory Docker Metadata
       id: edc_controlplane_memory_meta
       uses: docker/metadata-action@v3
       with:
@@ -74,7 +75,7 @@ jobs:
           type=match,pattern=\d.\d.\d
           type=sha
     -
-      name: Build Docker Image
+      name: Build edc-controlplane-memory Docker Image
       uses: docker/build-push-action@v2
       with:
         context: .
@@ -96,7 +97,7 @@ jobs:
         GITHUB_PACKAGE_USERNAME: ${{ github.actor }}
         GITHUB_PACKAGE_PASSWORD: ${{ secrets.CXNG_GHCR_PAT }}
     -
-      name: Docker Metadata
+      name: edc-controlplane-cosmosdb Docker Metadata
       id: edc_controlplane_cosmosdb_meta
       uses: docker/metadata-action@v3
       with:
@@ -109,7 +110,7 @@ jobs:
           type=match,pattern=\d.\d.\d
           type=sha
     -
-      name: Build Docker Image
+      name: Build edc-controlplane-cosmosdb Docker Image
       uses: docker/build-push-action@v2
       with:
         context: .
@@ -131,7 +132,7 @@ jobs:
         GITHUB_PACKAGE_USERNAME: ${{ github.actor }}
         GITHUB_PACKAGE_PASSWORD: ${{ secrets.CXNG_GHCR_PAT }}
     -
-      name: Docker Metadata
+      name: edc-dataplane Docker Metadata
       id: edc_dataplane_meta
       uses: docker/metadata-action@v3
       with:
@@ -144,7 +145,7 @@ jobs:
           type=match,pattern=\d.\d.\d
           type=sha
     -
-      name: Build Docker Image
+      name: Build edc-dataplane Docker Image
       uses: docker/build-push-action@v2
       with:
         context: .


### PR DESCRIPTION
Sets the "edc" git submodules version to [3305340d6a19ba919540d28a731b3cab6d23857a](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/commit/3305340d6a19ba919540d28a731b3cab6d23857a).

<sub> Denis Neuling <denis.neuling@daimler.com>, Daimler TSS GmbH, [legal info/Impressum](https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md)
